### PR TITLE
Fixing azure content-type sent by strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,74 @@ npm install strapi-provider-upload-azure-storage-blob --save
 
 ## Usage
 
-### Strapi version >= 3.0.0
+### Strapi version >= 4.0.0
+
+To enable the provider, create or edit the file at ```./config/plugins.js```.
+
+This is an example plugins.js file for Azure storage:
+```JavaScript
+/* AZURE IDENTITY */
+module.exports = ({ env }) => ({
+  upload: {
+    config: {
+      provider: 'azure-storage-blob',
+      providerOptions: {
+        account: env('STORAGE_ACCOUNT'),
+        accountKey: env('STORAGE_ACCOUNT_KEY'),
+        serviceBaseURL: env('STORAGE_URL'),
+        containerName: env('STORAGE_CONTAINER_NAME'),
+        defaultPath: 'assets',
+      }
+    }
+  }
+});
+/* AZURE SAS TOKEN */
+module.exports = ({ env }) => ({
+  upload: {
+    config: {
+      provider: 'azure-storage-blob',
+      providerOptions: {
+        account: env('STORAGE_ACCOUNT'),
+        serviceBaseURL: env('STORAGE_URL'),
+        containerName: env('STORAGE_CONTAINER_NAME'),
+        defaultPath: 'assets',
+      }
+    }
+  }
+});
+/* AZURE CONNECTION STRING */
+module.exports = ({ env }) => ({
+  upload: {
+    config: {
+      provider: 'azure-storage-blob',
+      providerOptions: {
+        account: env('STORAGE_ACCOUNT'),
+        serviceBaseURL: env('STORAGE_URL'),
+        containerName: env('STORAGE_CONTAINER_NAME'),
+        connectionString: env('STORAGE_CONNECTION_STRING'),
+        defaultPath: 'assets',
+      }
+    }
+  }
+});
+/* AZURE STORAGE CREDENTIAL */
+module.exports = ({ env }) => ({
+  upload: {
+    config: {
+      provider: 'azure-storage-blob',
+      providerOptions: {
+        account: env('STORAGE_ACCOUNT'),
+        accountKey: env('STORAGE_ACCOUNT_KEY'),
+        serviceBaseURL: env('STORAGE_URL'),
+        containerName: env('STORAGE_CONTAINER_NAME'),
+        defaultPath: 'assets',
+      }
+    }
+  }
+});
+```
+
+### Strapi version < 4.0.0 and >= 3.0.0
 
 With a stable release of Strapi 3.0.0, the configuration was moved to a JavaScript file. Official documentation [here](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#using-a-provider).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ module.exports = {
                 return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
                     const containerClient = client.getContainerClient(containerName);
                     const blobClient = containerClient.getBlockBlobClient(`${defaultPath}/${file.name}`);
-                    const options = { blobHTTPHeaders: Object.assign({ blobContentType: file.type }, customParams) };
+                    const options = { blobHTTPHeaders: Object.assign({ blobContentType: file.mime }, customParams) };
                     const result = yield blobClient.uploadData(file, options);
                     file.url = blobClient.url;
                     resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ module.exports = {
                     const blobClient = containerClient.getBlockBlobClient(`${defaultPath}/${file.name}`);
 
                     // set mimetype as determined from browser with file upload control
-                    const options = { blobHTTPHeaders: { blobContentType: file.type, ...customParams, } };
+                    const options = { blobHTTPHeaders: { blobContentType: file.mime, ...customParams, } };
 
                     // upload file
                     const result = await blobClient.uploadData(file,options);


### PR DESCRIPTION
This PR is basically to:
- Update the readme with instructions for Strapi >= v4;

- Fix the file content-type sent to azure on file upload. 
  `file.type` is `undefined` on both strapi v3 and v4. If `undefined` content-type is sent to Azure, it forces the download of files like images/pdf etc, instead of properly showing them while accessing from a browser;